### PR TITLE
Delegate Request to the Next Plugin in 0 Matches

### DIFF
--- a/coredns/plugin/pdsql/pdsql.go
+++ b/coredns/plugin/pdsql/pdsql.go
@@ -3,14 +3,16 @@
 package pdsql
 
 import (
-	"github.com/coredns/coredns/request"
-	"github.com/jinzhu/gorm"
-	"github.com/miekg/dns"
-	"github.com/wenerme/wps/pdns/model"
-	"golang.org/x/net/context"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/request"
+	"github.com/jinzhu/gorm"
+	"github.com/miekg/dns"
+	pdnsmodel "github.com/wenerme/wps/pdns/model"
+	"golang.org/x/net/context"
 )
 
 const Name = "pdsql"
@@ -18,6 +20,7 @@ const Name = "pdsql"
 type PowerDNSGenericSQLBackend struct {
 	*gorm.DB
 	Debug bool
+	Next  plugin.Handler
 }
 
 func (self PowerDNSGenericSQLBackend) Name() string { return Name }
@@ -107,6 +110,9 @@ func (self PowerDNSGenericSQLBackend) ServeDNS(ctx context.Context, w dns.Respon
 				a.Answer = append(a.Answer, rr)
 			}
 		}
+	}
+	if len(a.Answer) == 0 {
+		return plugin.NextOrFailure(self.Name(), self.Next, ctx, w, r)
 	}
 
 	return 0, w.WriteMsg(a)

--- a/coredns/plugin/pdsql/setup.go
+++ b/coredns/plugin/pdsql/setup.go
@@ -1,12 +1,13 @@
 package pdsql
 
 import (
+	"log"
+
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/jinzhu/gorm"
 	"github.com/mholt/caddy"
-	"github.com/wenerme/wps/pdns/model"
-	"log"
+	pdnsmodel "github.com/wenerme/wps/pdns/model"
 )
 
 func init() {
@@ -64,7 +65,10 @@ func setup(c *caddy.Controller) error {
 
 	dnsserver.
 		GetConfig(c).
-		AddPlugin(func(next plugin.Handler) plugin.Handler { return backend })
+		AddPlugin(func(next plugin.Handler) plugin.Handler {
+			backend.Next = next
+			return backend
+		})
 
 	return nil
 }


### PR DESCRIPTION
Currently this plugin acts as a sinkhole if no matches are found in the database. It makes it unusable to be used in an internal DNS server to lookup the address of internal services before forwarding it to another plugin that can find the address.

I found this shortcoming when I tried to use this plugin for my internal network.