### PR TITLE
update caddyserver path

### DIFF
--- a/coredns/plugin/ipin/setup.go
+++ b/coredns/plugin/ipin/setup.go
@@ -3,7 +3,7 @@ package ipin
 import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func init() {


### PR DESCRIPTION
caddy has changed it's home and Go modules are not mature enough yet to handle this, so this change breaks compiles for CoreDNS